### PR TITLE
No11, No13, No14 Extended NoBenefit message

### DIFF
--- a/__tests__/getQuestions.test.tsx
+++ b/__tests__/getQuestions.test.tsx
@@ -231,7 +231,7 @@ describe("getQuestions['6']", () => {
     question.actions.yes();
 
     expect(mockSetToStep).toHaveBeenCalledWith('6');
-    expect(mockSetJourneyEnd).toHaveBeenCalledWith(EndJourneyType.NoBenefitWithThirdDose);
+    expect(mockSetJourneyEnd).toHaveBeenCalledWith(EndJourneyType.NoBenefitExtended);
   });
 
   it('has an action "no" that sets step to 7 with no end journey', () => {

--- a/__tests__/getQuestions.test.tsx
+++ b/__tests__/getQuestions.test.tsx
@@ -321,7 +321,7 @@ describe("getQuestions['8a']", () => {
   it('has an action "no" that sets journey end to "NoBenefit"', () => {
     question.actions.no();
 
-    expect(mockSetJourneyEnd).toHaveBeenCalledWith(EndJourneyType.NoBenefit);
+    expect(mockSetJourneyEnd).toHaveBeenCalledWith(EndJourneyType.NoBenefitExtended);
   });
 });
 
@@ -469,7 +469,7 @@ describe("getQuestions['9c']", () => {
     question.actions.no();
 
     expect(mockSetToStep).toHaveBeenCalledWith('9c');
-    expect(mockSetJourneyEnd).toHaveBeenCalledWith(EndJourneyType.NoBenefit);
+    expect(mockSetJourneyEnd).toHaveBeenCalledWith(EndJourneyType.NoBenefitExtended);
   });
 });
 
@@ -506,6 +506,6 @@ describe("getQuestions['10b']", () => {
     question.actions.no();
 
     expect(mockSetToStep).toHaveBeenCalledWith('10b');
-    expect(mockSetJourneyEnd).toHaveBeenCalledWith(EndJourneyType.NoBenefit);
+    expect(mockSetJourneyEnd).toHaveBeenCalledWith(EndJourneyType.NoBenefitExtended);
   });
 });

--- a/components/EndOfJourney.tsx
+++ b/components/EndOfJourney.tsx
@@ -2,7 +2,7 @@ import { ServiceBCLink } from './ServiceBCLink';
 
 export enum EndJourneyType {
   NoBenefit,
-  NoBenefitWithThirdDose,
+  NoBenefitExtended,
   UrgentCare,
   TooManyDays,
   AntiviralBenefit,
@@ -16,8 +16,8 @@ export const EndOfJourney: React.FC<EndOfJourneyProps> = ({ journeyEnd }) => {
   switch (journeyEnd) {
     case EndJourneyType.NoBenefit:
       return <NoBenefit />;
-    case EndJourneyType.NoBenefitWithThirdDose:
-      return <NoBenefitWithThirdDose />;
+    case EndJourneyType.NoBenefitExtended:
+      return <NoBenefitExtended />;
     case EndJourneyType.UrgentCare:
       return <UrgentCare />;
     case EndJourneyType.TooManyDays:
@@ -61,7 +61,7 @@ const NoBenefit: React.FC = () => (
   </EndOfJourneyContainer>
 );
 
-const NoBenefitWithThirdDose: React.FC = () => (
+const NoBenefitExtended: React.FC = () => (
   <EndOfJourneyContainer>
     <EndOfJourneyTitle>
       Based on your answers you would likely not benefit from antivirals for COVID-19 at this time.

--- a/components/questions/structure.ts
+++ b/components/questions/structure.ts
@@ -175,7 +175,7 @@ export const getQuestions: ({
         setJourneyEnd(EndJourneyType.AntiviralBenefit);
       },
       no: () => {
-        setJourneyEnd(EndJourneyType.NoBenefit);
+        setJourneyEnd(EndJourneyType.NoBenefitExtended);
       },
     },
   },
@@ -251,7 +251,7 @@ export const getQuestions: ({
       },
       no: () => {
         setToStep('9c');
-        setJourneyEnd(EndJourneyType.NoBenefit);
+        setJourneyEnd(EndJourneyType.NoBenefitExtended);
       },
     },
   },
@@ -270,7 +270,7 @@ export const getQuestions: ({
       },
       no: () => {
         setToStep('10b');
-        setJourneyEnd(EndJourneyType.NoBenefit);
+        setJourneyEnd(EndJourneyType.NoBenefitExtended);
       },
     },
   },

--- a/components/questions/structure.ts
+++ b/components/questions/structure.ts
@@ -130,7 +130,7 @@ export const getQuestions: ({
     actions: {
       yes: () => {
         setToStep('6');
-        setJourneyEnd(EndJourneyType.NoBenefitWithThirdDose);
+        setJourneyEnd(EndJourneyType.NoBenefitExtended);
       },
       no: () => {
         setJourneyEnd(null);


### PR DESCRIPTION
Change # | Summary | Description
-- | -- | --
11 | Update the "not likely to benefit from antivirals text" with the new text that includes three additional bullets for the under 60s path | This updated text includes an additional paragraph with bullets addressing cases of immunocompromised, unvaxed or partially vaxed etc.
13 | Update the "not likely to benefit from antivirals text" with the new text that includes three additional bullets for the 60-70 path | This updated text includes an additional paragraph with bullets addressing cases of immunocompromised, unvaxed or partially vaxed etc.
14 | Update the "not likely to benefit from antivirals text" with the new text that includes three additional bullets for the 70+ path | This updated text includes an additional paragraph with bullets addressing cases of immunocompromised, unvaxed or partially vaxed etc.

![image](https://user-images.githubusercontent.com/71518072/151452159-80ff248f-760b-43fb-a768-1a4f6d7221c6.png)
![image](https://user-images.githubusercontent.com/71518072/151452258-c772e0b6-8cda-4992-b261-148b30d8c1e4.png)
![image](https://user-images.githubusercontent.com/71518072/151452277-353d9426-def4-4468-bbe3-39671b8845d4.png)

