### PR TITLE
Fix typos

### DIFF
--- a/components/EndOfJourney.tsx
+++ b/components/EndOfJourney.tsx
@@ -45,7 +45,7 @@ const NoBenefit: React.FC = () => (
     <p>
       These medications have been approved specifically for people experiencing mild-moderate
       COVID-19 symptoms and require a positive test to be confirmed. As with most medications, there
-      can be side effects when they are not used for their intended purpose.If you are experiencing
+      can be side effects when they are not used for their intended purpose. If you are experiencing
       symptoms and are at risk of more severe disease due to personal risk factors, you are
       encouraged to get tested. For more information, go to{' '}
       <a

--- a/components/EndOfJourney.tsx
+++ b/components/EndOfJourney.tsx
@@ -131,7 +131,7 @@ const TooManyDays: React.FC = () => (
       status)there may be some cases where this timeframe is extended up to 10 days. This would be
       reviewed on a case by case basis.{' '}
       <strong>
-        If you fit into this group, please call ServicesBC so they can start the assessment process.
+        If you fit into this group, please call ServiceBC so they can start the assessment process.
       </strong>
     </p>
   </EndOfJourneyContainer>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -67,7 +67,7 @@ export default function Home() {
         <p>
           Please consider and answer each question carefully. Your responses will help to determine
           if it would be safe for you to receive an anti-viral treatment for COVID-19. If it looks
-          like you might benefit from the treatment you will be directed to call ServicesBC so
+          like you might benefit from the treatment you will be directed to call ServiceBC so
           thatthey can startthe assessment process. They will take the time to review these
           questions in more detailwith you, and may support your connection to a healthcare team who
           can access your medication and health information, seek more information,and make
@@ -77,7 +77,7 @@ export default function Home() {
 
       <InfoBox>
         If for any reason you are unable to fill out the questionnaire online and would like to
-        complete it over the phone with support, please call ServicesBC at <ServiceBCLink /> and
+        complete it over the phone with support, please call ServiceBC at <ServiceBCLink /> and
         someone can assist you.
       </InfoBox>
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -23,7 +23,7 @@ export default function Home() {
         <p>
           Treatment is available for some people who have tested positive for COVID-19. These
           treatments have been approved for use in Canada to prevent worsening symptoms in
-          vulnerable patients. . They have been shown to prevent COVID-19 from progressing in high
+          vulnerable patients. They have been shown to prevent COVID-19 from progressing in high
           risk patients with mild to moderate symptoms, if taken within 5 to 7 days of symptom
           onset. They are not used to prevent COVID-19, before or after an exposure. There are
           important considerations, such as medication interactions,that may limit their use for

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -69,8 +69,8 @@ export default function Home() {
           if it would be safe for you to receive an anti-viral treatment for COVID-19. If it looks
           like you might benefit from the treatment you will be directed to call ServiceBC so
           thatthey can startthe assessment process. They will take the time to review these
-          questions in more detailwith you, and may support your connection to a healthcare team who
-          can access your medication and health information, seek more information,and make
+          questions in more detail with you, and may support your connection to a healthcare team
+          who can access your medication and health information, seek more information, and make
           decisions based on their clinical assessment.
         </p>
       </div>


### PR DESCRIPTION
### Home Page
- Space after period `intended purpose.If you are`
- ServicesBC -> ServiceBC `please call ServicesBC so they`
- Double period `vulnerable patients. . They have been`
- Add space between words `in more detailwith you, and`
- Add space after oxford comma `more information, and make`

### Questions (Fixed in previous PRs)
- ServicesBC -> ServiceBC `please call ServicesBC so they`
- Double period `assessment process. . Let`