### PR TITLE
Feb7 no5, no4 - update q2 content + end of journey

### DIFF
--- a/__tests__/getQuestions.test.tsx
+++ b/__tests__/getQuestions.test.tsx
@@ -85,11 +85,11 @@ describe("getQuestions['2']", () => {
     expect(mockSetJourneyEnd).toHaveBeenCalledWith(null);
   });
 
-  it('has an action "no" that sets step to 2 and journey end to "NoBenefit"', () => {
+  it('has an action "no" that sets step to 2 and journey end to "NoBenefitNoPositiveTest"', () => {
     question.actions.no();
 
     expect(mockSetToStep).toHaveBeenCalledWith('2');
-    expect(mockSetJourneyEnd).toHaveBeenCalledWith(EndJourneyType.NoBenefit);
+    expect(mockSetJourneyEnd).toHaveBeenCalledWith(EndJourneyType.NoBenefitNoPositiveTest);
   });
 });
 

--- a/components/EndOfJourney.tsx
+++ b/components/EndOfJourney.tsx
@@ -3,6 +3,7 @@ import { ServiceBCLink } from './ServiceBCLink';
 export enum EndJourneyType {
   NoBenefit,
   NoBenefitUnder12,
+  NoBenefitNoPositiveTest,
   NoBenefitExtended,
   UrgentCare,
   TooManyDays,
@@ -19,6 +20,8 @@ export const EndOfJourney: React.FC<EndOfJourneyProps> = ({ journeyEnd }) => {
       return <NoBenefit />;
     case EndJourneyType.NoBenefitUnder12:
       return <NoBenefitUnder12 />;
+    case EndJourneyType.NoBenefitNoPositiveTest:
+      return <NoBenefitNoPositiveTest />;
     case EndJourneyType.NoBenefitExtended:
       return <NoBenefitExtended />;
     case EndJourneyType.UrgentCare:
@@ -61,6 +64,33 @@ const NoBenefit: React.FC = () => (
         http://www.bccdc.ca/health-info/diseases-conditions/covid-19/testing/when-to-get-a-covid-19-test
       </a>
     </p>
+  </EndOfJourneyContainer>
+);
+
+const NoBenefitNoPositiveTest: React.FC = () => (
+  <EndOfJourneyContainer>
+    <EndOfJourneyTitle>
+      Based on your answer you would likely not benefit from the available therapeutics t for
+      COVID-19 at this time.
+    </EndOfJourneyTitle>
+    <div className='flex flex-col gap-4'>
+      <p>
+        These treatments have been approved specifically for people experiencing mild to moderate
+        COVID-19 symptoms, and require a positive test. As with most medications, there can be side
+        effects if they are not used correctly.
+      </p>
+      <p>
+        If you are experiencing symptoms and are at risk of more severe disease due to personal risk
+        factors, you are encouraged to get tested. Visit the{' '}
+        <a
+          target='_blank'
+          rel='noreferrer'
+          href='http://www.bccdc.ca/health-info/diseases-conditions/covid-19/testing/when-to-get-a-covid-19-test'
+        >
+          BCCDC website for more information about COVID-19 testing.
+        </a>
+      </p>
+    </div>
   </EndOfJourneyContainer>
 );
 

--- a/components/questions/QuestionProps.ts
+++ b/components/questions/QuestionProps.ts
@@ -1,6 +1,6 @@
 export interface QuestionProps {
   description: React.ReactElement | null;
-  question: string;
+  question: React.ReactElement | string;
   questionKey: string;
   options: {
     key: string;

--- a/components/questions/structure.ts
+++ b/components/questions/structure.ts
@@ -6,7 +6,7 @@ export interface Steps {
 }
 
 export interface Question {
-  question: string;
+  question: React.ReactElement | string;
   description: React.ReactElement | null;
   questionKey: string;
   options: { key: string; label: string }[];

--- a/components/questions/structure.ts
+++ b/components/questions/structure.ts
@@ -58,7 +58,7 @@ export const getQuestions: ({
       },
       no: () => {
         setToStep('2');
-        setJourneyEnd(EndJourneyType.NoBenefit);
+        setJourneyEnd(EndJourneyType.NoBenefitNoPositiveTest);
       },
     },
   },

--- a/content/Questions.tsx
+++ b/content/Questions.tsx
@@ -1,19 +1,20 @@
 export const Q1Question = '1.	Please confirm you are 12 years or older? born 2010 or earlier';
 export const Q1Description = null;
 
-export const Q2Question = '2. Have you recently tested positive for COVID-19?';
-export const Q2Description = (
-  <p>
-    For more information on types of COVID-19 tests,{' '}
+export const Q2Question = (
+  <>
+    2. Have you recently tested positive for COVID-19? For more information on types of COVID-19
+    tests,{' '}
     <a
-      className='underline'
-      href='http://www.bccdc.ca/health-info/diseases-conditions/covid-19/testing/types-of-tests'
+      href='http://www.bccdc.ca/health-info/diseases-conditions/covid-19/if-you-have-covid-19'
+      target='_blank'
+      rel='noreferrer'
     >
-      go to this link
+      review information from the BCCDC.
     </a>
-    .
-  </p>
+  </>
 );
+export const Q2Description = null;
 
 export const Q3Question = '3. Do you have any severe symptoms of COVID-19?';
 // TODO: UL needs to be fixed


### PR DESCRIPTION
Change   # | Summary | Description
-- | -- | --
5 | "Not   likely to benefit from antivirals" text for current Q1(new Q2) has been   changed | Update   the text to match the new text when a user is not likely to benefit from   Treatment for current questions 1(new Q2)
4 | Update current Question 1 text and make it as Question 2 | Update Question text - i.e. Add "For more information on types of COVID-19 tests, review information from the BCCDC." after ? in current 1st question (new Q2)


![image](https://user-images.githubusercontent.com/71518072/153022487-6cc3c82f-804e-4373-bb0b-893ea443fdfd.png)

![image](https://user-images.githubusercontent.com/71518072/153022503-5f7b2ce9-86c1-4895-b672-ed5e611ea470.png)
4	Update current Question 1 text and make it as Question 2	Update Question text - i.e. Add "For more information on types of COVID-19 tests, [review information from the BCCDC.](http://www.bccdc.ca/health-info/diseases-conditions/covid-19/testing/types-of-tests)" after ? in current 1st question (new Q2)