### PR TITLE
Feb7 no7 - update q4 end of journey

### DIFF
--- a/__tests__/getQuestions.test.tsx
+++ b/__tests__/getQuestions.test.tsx
@@ -161,7 +161,7 @@ describe("getQuestions['4']", () => {
     question.actions.no();
 
     expect(mockSetToStep).toHaveBeenCalledWith('4');
-    expect(mockSetJourneyEnd).toHaveBeenCalledWith(EndJourneyType.NoBenefit);
+    expect(mockSetJourneyEnd).toHaveBeenCalledWith(EndJourneyType.NoBenefitNoSymptoms);
   });
 });
 

--- a/components/EndOfJourney.tsx
+++ b/components/EndOfJourney.tsx
@@ -4,6 +4,7 @@ export enum EndJourneyType {
   NoBenefit,
   NoBenefitUnder12,
   NoBenefitNoPositiveTest,
+  NoBenefitNoSymptoms,
   NoBenefitExtended,
   UrgentCare,
   TooManyDays,
@@ -22,6 +23,8 @@ export const EndOfJourney: React.FC<EndOfJourneyProps> = ({ journeyEnd }) => {
       return <NoBenefitUnder12 />;
     case EndJourneyType.NoBenefitNoPositiveTest:
       return <NoBenefitNoPositiveTest />;
+    case EndJourneyType.NoBenefitNoSymptoms:
+      return <NoBenefitNoSymptoms />;
     case EndJourneyType.NoBenefitExtended:
       return <NoBenefitExtended />;
     case EndJourneyType.UrgentCare:
@@ -104,6 +107,35 @@ const NoBenefitUnder12: React.FC = () => (
       <p>
         You should continue to seek medical care if you feel you need it. For more information,
         visit the BCCDC website.
+      </p>
+    </div>
+  </EndOfJourneyContainer>
+);
+
+const NoBenefitNoSymptoms: React.FC = () => (
+  <EndOfJourneyContainer>
+    <EndOfJourneyTitle>
+      Based on your answer you would likely not benefit from the available therapeutics for COVID-19
+      at this time.
+    </EndOfJourneyTitle>
+    <div className='flex flex-col gap-4'>
+      <p>
+        These medications have been approved specifically for people experiencing mild to moderate
+        COVID-19 symptoms. As with most medications, there may be side effects to taking these
+        treatments if you do not have COVID-19 symptoms.
+      </p>
+
+      <p>
+        If you start to experience symptoms and are at risk of developing more severe disease due to
+        personal risk factors, you should re-visit this screening tool or call Service BC at
+        1-888-COVID19. Visit the{' '}
+        <a
+          target='_blank'
+          rel='noreferrer'
+          href='http://www.bccdc.ca/health-info/diseases-conditions/covid-19/testing/when-to-get-a-covid-19-test'
+        >
+          BCCDC website for more information about COVID-19 testing.
+        </a>
       </p>
     </div>
   </EndOfJourneyContainer>

--- a/components/questions/structure.ts
+++ b/components/questions/structure.ts
@@ -96,7 +96,7 @@ export const getQuestions: ({
       },
       no: () => {
         setToStep('4');
-        setJourneyEnd(EndJourneyType.NoBenefit);
+        setJourneyEnd(EndJourneyType.NoBenefitNoSymptoms);
       },
     },
   },


### PR DESCRIPTION
Change   # | Summary | Description
-- | -- | --
7 | "Not   likely to benefit from antivirals" text for current Q3(new Q4) has been   changed | Update   the text to match the new text when a user is not likely to benefit from   antivirals for current questions 3(new Q4).

![image](https://user-images.githubusercontent.com/71518072/153024762-421afb8b-29e8-46cf-baa9-3a1936cc3b26.png)
![image](https://user-images.githubusercontent.com/71518072/153024701-e3dc6c4a-74a2-4c56-93ba-19394aebaa72.png)
