### PR TITLE
Content update

### DIFF
--- a/__tests__/getQuestions.test.tsx
+++ b/__tests__/getQuestions.test.tsx
@@ -157,11 +157,11 @@ describe("getQuestions['4']", () => {
     expect(mockSetJourneyEnd).toHaveBeenCalledWith(null);
   });
 
-  it('has an action "no" that sets journey end to "NoBenefitNoSymptoms"', () => {
+  it('has an action "no" that sets journey end to "NoBenefitExtended"', () => {
     question.actions.no();
 
     expect(mockSetToStep).toHaveBeenCalledWith('4');
-    expect(mockSetJourneyEnd).toHaveBeenCalledWith(EndJourneyType.NoBenefitNoSymptoms);
+    expect(mockSetJourneyEnd).toHaveBeenCalledWith(EndJourneyType.NoBenefitExtended);
   });
 });
 

--- a/components/EndOfJourney.tsx
+++ b/components/EndOfJourney.tsx
@@ -45,10 +45,6 @@ const EndOfJourneyTitle: React.FC = ({ children }) => {
 
 const NoBenefitNoPositiveTest: React.FC = () => (
   <EndOfJourneyContainer>
-    <EndOfJourneyTitle>
-      Based on your answer you would likely not benefit from the available treatments for COVID-19
-      at this time. You need a positive test result.
-    </EndOfJourneyTitle>
     <div className='flex flex-col gap-4'>
       <p>
         These treatments have been approved specifically for people experiencing mild to moderate
@@ -71,10 +67,6 @@ const NoBenefitNoPositiveTest: React.FC = () => (
 
 const NoBenefitUnder12: React.FC = () => (
   <EndOfJourneyContainer>
-    <EndOfJourneyTitle>
-      Based on your answer you would likely not benefit from the available treatments for COVID-19
-      at this time. These treatments have only been approved for ages 12 years and older.{' '}
-    </EndOfJourneyTitle>
     <div className='flex flex-col gap-4'>
       <p>
         You should continue to seek medical care if you feel you need it. For more information,

--- a/components/EndOfJourney.tsx
+++ b/components/EndOfJourney.tsx
@@ -45,6 +45,7 @@ const EndOfJourneyTitle: React.FC = ({ children }) => {
 
 const NoBenefitNoPositiveTest: React.FC = () => (
   <EndOfJourneyContainer>
+    <EndOfJourneyTitle>You need a positive test result.</EndOfJourneyTitle>
     <div className='flex flex-col gap-4'>
       <p>
         These treatments have been approved specifically for people experiencing mild to moderate
@@ -67,6 +68,9 @@ const NoBenefitNoPositiveTest: React.FC = () => (
 
 const NoBenefitUnder12: React.FC = () => (
   <EndOfJourneyContainer>
+    <EndOfJourneyTitle>
+      These treatments have only been approved for ages 12 years and older.
+    </EndOfJourneyTitle>
     <div className='flex flex-col gap-4'>
       <p>
         You should continue to seek medical care if you feel you need it. For more information,

--- a/components/EndOfJourney.tsx
+++ b/components/EndOfJourney.tsx
@@ -115,9 +115,9 @@ const NoBenefitNoSymptoms: React.FC = () => (
 const NoBenefitExtended: React.FC = () => (
   <EndOfJourneyContainer>
     <p className='mb-2'>
-      Based on your answers this treatment isn&apos;t the right option for you. These treatments are
-      currently being recommended for individuals who are identified as being at increased risk of
-      hospitalization for COVID-19.
+      Based on your answers, Sotrovimab or Paxlovid aren&apos;t the right treatments for you at this
+      time. These treatments are currently being recommended for individuals who are identified as
+      being at increased risk of hospitalization for COVID-19.
     </p>
 
     <p className='mb-2'>

--- a/components/questions/structure.tsx
+++ b/components/questions/structure.tsx
@@ -96,7 +96,7 @@ export const getQuestions: ({
       },
       no: () => {
         setToStep('4');
-        setJourneyEnd(EndJourneyType.NoBenefitNoSymptoms);
+        setJourneyEnd(EndJourneyType.NoBenefitExtended);
       },
     },
   },


### PR DESCRIPTION
### Q 1: Remove first sentence in “no” response.
![image](https://user-images.githubusercontent.com/71518072/156083951-ca287ff1-51ff-4137-b625-917d55c585ca.png)

### Q 2: Remove first sentence in “no” response.
![image](https://user-images.githubusercontent.com/71518072/156083957-a6a80bcc-8e56-4a8b-aabf-c172764dd5f9.png)

### Q4 (No Response), Q7 (Yes Response), Under 60 (not likely to benefit), 60-69 (not likely to benefit), above 70 (not likely to benefit)
![image](https://user-images.githubusercontent.com/71518072/156084014-f3ff97dc-f4db-4add-923e-75b1e6f3221b.png)


